### PR TITLE
An example of the documentation:

### DIFF
--- a/Security/Authentication/Provider/Provider.php
+++ b/Security/Authentication/Provider/Provider.php
@@ -54,7 +54,7 @@ class Provider implements AuthenticationProviderInterface
 		}
 
 		//validate secret
-		$expected = base64_encode(sha1(base64_decode($nonce.$created.$secret), true));
+		$expected = base64_encode(sha1(base64_decode($nonce).$created.$secret), true));
 
 		return $digest === $expected;
 	}


### PR DESCRIPTION
<code>$expected = base64_encode (sha1 (base64_decode ($ nonce). $ created. $ secret, true));</code>

It makes no sense to encode in base64 time and security by following the standards WSSE
