### PR TITLE
Fixed Error

### DIFF
--- a/Security/Authentication/Provider/Provider.php
+++ b/Security/Authentication/Provider/Provider.php
@@ -31,6 +31,7 @@ class Provider implements AuthenticationProviderInterface
 		{
 			$authenticatedToken = new Token($user->getRoles());
 			$authenticatedToken->setUser($user);
+            $authenticatedToken->setAuthenticated(true);
 
 			return $authenticatedToken;
 		}


### PR DESCRIPTION
AbstractToken set to a $authenticated flag is false. It must be set true after authentication for successful authorization.
This is done for all other symfony tokens.
