### PR TITLE
Fix entry point - can not replace defaults paremeters

### DIFF
--- a/DependencyInjection/Security/Factory/Factory.php
+++ b/DependencyInjection/Security/Factory/Factory.php
@@ -63,8 +63,8 @@ class Factory implements SecurityFactoryInterface
 
         $container
             ->setDefinition($entryPointId, new DefinitionDecorator('escape_wsse_authentication.entry_point'))
-            ->addArgument($config['realm'])
-            ->addArgument($config['profile']);
+            ->replaceArgument(1, $config['realm'])
+            ->replaceArgument(2, $config['profile']);
 
         return $entryPointId;
     }


### PR DESCRIPTION
Custom real and profile parameters from security.yml do not replace defaults values from configuration.
