### PR TITLE
Fix validation of unique nonce

### DIFF
--- a/Security/Core/Authentication/Provider/Provider.php
+++ b/Security/Core/Authentication/Provider/Provider.php
@@ -51,7 +51,7 @@ class Provider implements AuthenticationProviderInterface
         if($this->nonceDir)
         {
             //validate nonce is unique within specified lifetime
-            if(file_exists($this->nonceDir.'/'.$nonce) && file_get_contents($this->nonceDir.'/'.$nonce) + $this->lifetime < time())
+            if(file_exists($this->nonceDir.'/'.$nonce) && file_get_contents($this->nonceDir.'/'.$nonce) + $this->lifetime > time())
             {
                 throw new NonceExpiredException('Previously used nonce detected.');
             }


### PR DESCRIPTION
Due to an incorrect comparison of the nonce time with the current time, a nonce could be used multiple times within specified lifetime. Thus the implementation was vulnerable to replay attacks.
