### PR TITLE
Future check

### DIFF
--- a/Security/Core/Authentication/Provider/Provider.php
+++ b/Security/Core/Authentication/Provider/Provider.php
@@ -61,7 +61,7 @@ class Provider implements AuthenticationProviderInterface
     protected function validateDigest($user, $digest, $nonce, $created, $secret)
     {
         //check whether timestamp is not in the future
-        if($this->isTokenFromFuture())
+        if($this->isTokenFromFuture($created))
         {
             throw new CredentialsExpiredException('Future token detected.');
         }
@@ -120,7 +120,7 @@ class Provider implements AuthenticationProviderInterface
         return $token instanceof Token;
     }
 
-    protected function isTokenFromFuture(){
+    protected function isTokenFromFuture($created){
         return strtotime($created) > time();
     }
 }


### PR DESCRIPTION
You cannot force the clients to be running exactly the same time as the server. I personally had this issue, where the server was not even tolerating a difference in seconds. Moving the future check logic to a protected method so other implementations can apply their own logic to check for future tokens.
