### PR TITLE
Fix token expiration timezone bug

### DIFF
--- a/Security/Core/Authentication/Provider/Provider.php
+++ b/Security/Core/Authentication/Provider/Provider.php
@@ -81,8 +81,10 @@ class Provider implements AuthenticationProviderInterface
             throw new CredentialsExpiredException('Future token detected.');
         }
 
+        $currentTime = gmdate('Y-m-d\TH:i:s\Z');
+
         //expire timestamp after specified lifetime
-        if(time() - strtotime($created) > $this->lifetime)
+        if(strtotime($currentTime) - strtotime($created) > $this->lifetime)
         {
             throw new CredentialsExpiredException('Token has expired.');
         }


### PR DESCRIPTION
There is bug in token expire validation when timezone is not GMT. This should fix it. 
