### PR TITLE
Fix malformed X-WSSE header vulnerability

### DIFF
--- a/Tests/Security/Http/Firewall/ListenerTest.php
+++ b/Tests/Security/Http/Firewall/ListenerTest.php
@@ -6,6 +6,7 @@ use Escape\WSSEAuthenticationBundle\Security\Http\Firewall\Listener;
 use Escape\WSSEAuthenticationBundle\Security\Core\Authentication\Token\Token;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class ListenerTest extends \PHPUnit_Framework_TestCase
 {
@@ -79,4 +80,50 @@ class ListenerTest extends \PHPUnit_Framework_TestCase
         $listener = new Listener($this->securityContext, $this->authenticationManager, $this->authenticationEntryPoint);
         $listener->handle($this->responseEvent);
     }
+
+    /**
+     * @test
+     */
+    public function handleReturnResponseWithNoWSSEHeader()
+    {
+        $token = new Token();
+        $token->setUser('admin');
+        $token->setAttribute('digest', 'admin');
+        $token->setAttribute('nonce', 'admin');
+        $token->setAttribute('created', '2010-12-12 20:00:00');
+        $response = new Response();
+
+        $this->authenticationEntryPoint->expects($this->once())->method('start')
+            ->with($this->request, new AuthenticationException())->will($this->returnValue($response));
+
+        // do not set an 'X-WSSE' request header
+
+        $listener = new Listener($this->securityContext, $this->authenticationManager, $this->authenticationEntryPoint);
+        $listener->handle($this->responseEvent);
+    }
+
+    /**
+     * @test
+     */
+    public function handleReturnResponseWithInvalidWSSEHeader()
+    {
+        $token = new Token();
+        $token->setUser('admin');
+        $token->setAttribute('digest', 'admin');
+        $token->setAttribute('nonce', 'admin');
+        $token->setAttribute('created', '2010-12-12 20:00:00');
+        $response = new Response();
+        $this->authenticationEntryPoint->expects($this->once())->method('start')
+            ->with($this->request, new AuthenticationException())->will($this->returnValue($response));
+
+        // set an invalid 'X-WSSE' header (missing opening quote on Username)   
+        
+        $this->request->headers->add(
+                               array('X-WSSE' => 'UsernameToken Username=admin", PasswordDigest="admin", Nonce="admin", Created="2010-12-12 20:00:00"')
+        );
+        
+        $listener = new Listener($this->securityContext, $this->authenticationManager, $this->authenticationEntryPoint);
+        $listener->handle($this->responseEvent);
+    }
+    
 }


### PR DESCRIPTION
This PR fixes two vulnerabilities related to not set or malformed X-WSSE header. 

Both problems happen because the current code assumes an "allowed by default" policy, while "denied by default" is a safer assumption.
### 1.- No X-WSSE header in request

if no X-WSSE header is set, authentication must be denied; otherwise it would be trivial to bypass the security just by sending a request without the X-WSSE header.
### 2.- Malformed X-WSSE header

If the X-WSSE header is present but malformed the authentication must also be denied, or again it would be trivial to bypass. 

I added one unit test for each one of the fixes.

BTW, thanks for this marvelous bundle!!!
