### PR TITLE
Enable specific provider for WSSE authentication.

### DIFF
--- a/DependencyInjection/Security/Factory/Factory.php
+++ b/DependencyInjection/Security/Factory/Factory.php
@@ -90,6 +90,7 @@ class Factory implements SecurityFactoryInterface
     {
         $node
             ->children()
+                ->scalarNode('provider')->end()
                 ->scalarNode('realm')->defaultValue(null)->end()
                 ->scalarNode('profile')->defaultValue('UsernameToken')->end()
                 ->scalarNode('lifetime')->defaultValue(300)->end()

--- a/README.md
+++ b/README.md
@@ -120,6 +120,31 @@ firewalls:
             nonce_cache_service_id: cache_nonces
 ```
 
+
+### Use a specific user provider for WSSE
+
+app/config/security.yml
+
+```
+providers:
+    user_db:
+        #...
+    wsse_users:
+        memory:
+            users:
+                user1:  { password: 'secret' }
+
+firewalls:
+    #...
+    wsse_secured:
+        provider: user_db
+        http_basic:
+            #...
+        wsse:
+            #...
+            provider: wsse_users
+```
+
 ### Specify custom authentication class(es)
 
 app/config/config.yml


### PR DESCRIPTION
This pull request adds the 'provider' configuration node, to use a specific provider for WSSE authentication. See example at http://symfony.com/doc/current/book/security.html#using-multiple-user-providers, where a specific provider is used for http_basic authentication.

The configuration is utilized by \Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension::createAuthenticationListeners() (line 399 in SF 2.6.1)

```
$userProvider = isset($firewall[$key]['provider']) ? $this->getUserProviderId($firewall[$key]['provider']) : $defaultProvider;
```

E.g. this configuration node is added by \Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory for form based authentication (FormLoginFactory and SimpleFormFactory) and by HttpBasicFactory. 

Since the password for WSSE has to be stored unhashed, as against to other authentication mechanisms like http basic, the same user provider can not be used for both mechanisms and thus it would be worthwhile to separate the providers.
