### PR TITLE
fixed deprecated yaml

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,6 +1,6 @@
 services:
     escape_wsse_authentication.provider:
-        class:  %escape_wsse_authentication.provider.class%
+        class:  '%escape_wsse_authentication.provider.class%'
         arguments: ['@security.user_checker', null, null, null, null, 300, '/^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/']
 
     escape_wsse_authentication.listener:
@@ -10,13 +10,13 @@ services:
           - '@security.authentication.manager'
 
     escape_wsse_authentication.entry_point:
-        class:  %escape_wsse_authentication.entry_point.class%
+        class:  '%escape_wsse_authentication.entry_point.class%'
         arguments: ['@logger', null, 'UsernameToken']
 
     escape_wsse_authentication.encoder:
-        class:  %escape_wsse_authentication.encoder.class%
+        class:  '%escape_wsse_authentication.encoder.class%'
         arguments: ['sha1', true, 1]
 
     escape_wsse_authentication.nonce_cache:
-        class:  %escape_wsse_authentication.nonce_cache.class%
-        arguments: [%kernel.cache_dir%/security/nonces]
+        class:  '%escape_wsse_authentication.nonce_cache.class%'
+        arguments: ['%kernel.cache_dir%/security/nonces']

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,7 +4,7 @@ services:
         arguments: ['@security.user_checker', null, null, null, null, 300, '/^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/']
 
     escape_wsse_authentication.listener:
-        class:  %escape_wsse_authentication.listener.class%
+        class:  '%escape_wsse_authentication.listener.class%'
         arguments:
           - null # replaced by @security.token_storage for SF >= 2.6, @security.context otherwise
           - '@security.authentication.manager'


### PR DESCRIPTION
Errors found after an upgrade of phpunit to latest version.
Looks like latest phpunit incorporates latest symfony yaml parser, which in turn deprecated some features that where never compliant with the Yaml specs... 
Needed to wrap the references to services and params with quotes
