### PR TITLE
Useless check for hash_equals method removed

### DIFF
--- a/Security/Core/Authentication/Provider/Provider.php
+++ b/Security/Core/Authentication/Provider/Provider.php
@@ -144,11 +144,7 @@ class Provider implements AuthenticationProviderInterface
             $salt
         );
 
-        if (class_exists('Symfony\Component\Security\Core\Util\StringUtils')) {
-            return \Symfony\Component\Security\Core\Util\StringUtils::equals($expected, $digest);
-        } else {
-            return hash_equals($expected, $digest);
-        }
+        return hash_equals($expected, $digest);
     }
 
     protected function getCurrentTime()


### PR DESCRIPTION
## Subject

Remove a useless check for string comparison.

## Causes

Since symfony-polyfill is required the method is always available.

This bundle required `symfony/security` library which [require](https://github.com/symfony/security/blob/master/composer.json) himself `symfony/polyfill-php56` that ensure this method is always available whatever the version of PHP running. 